### PR TITLE
check generated patch via diff

### DIFF
--- a/.github/workflows/test-pr-set.yml
+++ b/.github/workflows/test-pr-set.yml
@@ -137,6 +137,7 @@ jobs:
           # lower the go build version to 1.16
           sed -i "s/go mod tidy/go mod tidy -go=1.16/g" scripts/create-secondary-patch.sh
           ./scripts/setup-initial-patch.sh -r $(realpath ../openssl-fips) ${{ inputs.go_ref }}
+          git diff --exit-code patches/
 
       - name: "Apply FIPS patches"
         shell: bash


### PR DESCRIPTION
We want to ensure that the 001 patch committed in the repository for each branch is the most up to date patch so that when it is used to alter the Go tree during RPM builds it will always apply cleanly and produce the correct code.

We enforce this by issuing a `git diff` command with the `--exit-code` flag to fail the CI step if a diff is present.