### PR TITLE
Print go env after version

### DIFF
--- a/.github/workflows/test-ubi-centos.yml
+++ b/.github/workflows/test-ubi-centos.yml
@@ -88,6 +88,10 @@ jobs:
         shell: bash
         run: go version
 
+      - name: "Print Go env"
+        shell: bash
+        run: go env
+
       - name: "Print OpenSSL version"
         shell: bash
         run: openssl version


### PR DESCRIPTION
This will print the Go relevant environment variables, allowing us to see if the environment has been changed when tracking down failures in CI.