### PR TITLE
Don't modify Go module version

### DIFF
--- a/.github/workflows/test-ubi-centos.yml
+++ b/.github/workflows/test-ubi-centos.yml
@@ -120,6 +120,8 @@ jobs:
           # lower the go build version to 1.16
           sed -i "s/go mod tidy/go mod tidy -go=1.16/g" scripts/create-secondary-patch.sh
           ./scripts/full-initialize-repo.sh
+          # raise the go module version back to what is expected to prevent the toolchain from emulating older versions.
+          go mod edit -go="$(./go/bin/go version | awk '{ print $3 }' | sed 's/go//' | awk -F. '{printf "%s.%s\n", $1, $2}')" ./go/src/go.mod
 
       - name: "Configure FIPS tests"
         shell: bash

--- a/.github/workflows/test-ubi-centos.yml
+++ b/.github/workflows/test-ubi-centos.yml
@@ -117,11 +117,7 @@ jobs:
           # script requires a git repo
           git init
           git config --global --add safe.directory /__w/go/go
-          # lower the go build version to 1.16
-          sed -i "s/go mod tidy/go mod tidy -go=1.16/g" scripts/create-secondary-patch.sh
           ./scripts/full-initialize-repo.sh
-          # raise the go module version back to what is expected to prevent the toolchain from emulating older versions.
-          go mod edit -go="$(./go/bin/go version | awk '{ print $3 }' | sed 's/go//' | awk -F. '{printf "%s.%s\n", $1, $2}')" ./go/src/go.mod
 
       - name: "Configure FIPS tests"
         shell: bash


### PR DESCRIPTION
We currently set the Go module toolchain version to an earlier version to allow running `go mod tidy` from older versions. However, this has the side effect of making the Go toolchain emulate older Go versions. This breaks some standard library tests which expect current toolchain behavior.

Instead, do not modify the module version and instead use the new toolchain to run the `go mod ...` steps, which is done via https://github.com/golang-fips/go/pull/114.