### PR TITLE
Remove command lowering Go version before go mod tidy

### DIFF
--- a/.github/workflows/test-pr-set.yml
+++ b/.github/workflows/test-pr-set.yml
@@ -143,8 +143,6 @@ jobs:
           ls -Al *
           pushd go
           git config --global --add safe.directory /__w/go/go
-          # lower the go build version to 1.16
-          sed -i "s/go mod tidy/go mod tidy -go=1.16/g" scripts/create-secondary-patch.sh
           ./scripts/setup-initial-patch.sh -r $(realpath ../openssl-fips) ${{ inputs.go_ref }}
           git diff --exit-code patches/ >/dev/null 2>&1
           if [ $? -ne 0 ]; then


### PR DESCRIPTION
We did this historically because when using the host Go toolchain to run commands such as `go mod tidy` within the `go/src` directory it would fail because the host toolchain was lower than the new source toolchain. We now build the source toolchain first and then use it directly, effectively ignoring the host toolchain so this is no longer a problem.